### PR TITLE
Include missing files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+* 6.0.3
+  Include missing gem files in the release
+
 * 6.0.2
   Fix broken gemspec
 

--- a/bing-ads-reporting.gemspec
+++ b/bing-ads-reporting.gemspec
@@ -9,8 +9,9 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Allows easily pull reports from Bing Ads'
   gem.homepage      = 'https://github.com/forward3d/bing-ads-reporting'
 
-  gem.files         = ['lib/bing_ads_reporting.rb',
-                       'lib/bing-ads-reporting/version.rb']
+  gem.files         = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin)/}) }
+  end
 
   gem.executables   = [] # gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = [] # gem.files.grep(%r{^(test|spec|features)/})

--- a/lib/bing-ads-reporting/version.rb
+++ b/lib/bing-ads-reporting/version.rb
@@ -1,3 +1,3 @@
 module BingAdsReporting
-  VERSION = '6.0.2'.freeze
+  VERSION = '6.0.3'.freeze
 end


### PR DESCRIPTION
## Description

When moving to packages we should include all right files in the `gem.files`

This should fix

```
bundler: failed to load command: f3d-job (/usr/local/bundle/bin/f3d-job)
LoadError: cannot load such file -- /usr/local/bundle/gems/bing-ads-reporting-6.0.2/lib/bing-ads-reporting/bing_helper
  /usr/local/bundle/gems/bing-ads-reporting-6.0.2/lib/bing_ads_reporting.rb:1:in `require_relative'
  /usr/local/bundle/gems/bing-ads-reporting-6.0.2/lib/bing_ads_reporting.rb:1:in `<top (required)>'
  /code/job/download_worker.rb:1:in `require'
  /code/job/download_worker.rb:1:in `<top (required)>'
  /code/environment.rb:11:in `require'
  /code/environment.rb:11:in `block in <top (required)>'
  /code/environment.rb:10:in `each'
  /code/environment.rb:10:in `<top (required)>'
  /usr/local/bundle/gems/f3d-job-2.33.6/lib/f3d/job/framework.rb:14:in `require'
  /usr/local/bundle/gems/f3d-job-2.33.6/lib/f3d/job/framework.rb:14:in `execute'
  /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:66:in `run'
  /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/subcommand/execution.rb:18:in `execute'
  /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:66:in `run'
  /usr/local/bundle/gems/clamp-1.3.1/lib/clamp/command.rb:140:in `run'
  /usr/local/bundle/gems/f3d-job-2.33.6/bin/f3d-job:20:in `<top (required)>'
  /usr/local/bundle/bin/f3d-job:23:in `load'
  /usr/local/bundle/bin/f3d-job:23:in `<top (required)>'
```