### PR TITLE
fix/failing_bulk_service_api_requests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+* 6.0.4
+  Fix issue with failing V13/BulkService API requests
+
 * 6.0.3
   Include missing gem files in the release
 

--- a/lib/bing-ads-reporting/bulk_service.rb
+++ b/lib/bing-ads-reporting/bulk_service.rb
@@ -2,7 +2,7 @@ require_relative 'service_core'
 
 module BingAdsReporting
   class BulkService < ServiceCore
-    WDSL = 'https://bulk.api.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/BulkService.svc?wsdl'.freeze
+    WDSL = 'https://bulk.api.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/BulkService.svc?singleWsdl'.freeze
     FAILED_STATUS = 'Failed'.freeze
     SUCCESS_STATUS = 'Completed'.freeze
 

--- a/lib/bing-ads-reporting/version.rb
+++ b/lib/bing-ads-reporting/version.rb
@@ -1,3 +1,3 @@
 module BingAdsReporting
-  VERSION = '6.0.3'.freeze
+  VERSION = '6.0.4'.freeze
 end


### PR DESCRIPTION
This fixes an issue with failing Bing Bulk API requests.

The new code uses the single WSDL file for the https://bulk.api.bingads.microsoft.com/Api/Advertiser/CampaignManagement/V13/BulkService.svc endpoint.

Documentation References:

https://learn.microsoft.com/en-us/advertising/bulk-service/bulk-service-reference?view=bingads-13
https://learn.microsoft.com/en-us/advertising/guides/web-service-addresses?view=bingads-13