### PR TITLE
v6.0.5 - Fix httparty dependency issue

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+* 6.0.5
+  Fix dependency issue with httparty version in respect with f3d-job
+
 * 6.0.4
   Fix issue with failing V13/BulkService API requests
 

--- a/bing-ads-reporting.gemspec
+++ b/bing-ads-reporting.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = [] # gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'httparty', '~> 0.17.0'
+  gem.add_dependency 'httparty', '~> 0'
   gem.add_dependency 'datebox',  '~> 0.5.0'
   gem.add_dependency 'oauth2',   '~> 1.4.1'
   gem.add_dependency 'savon',    '~> 2.12.0'

--- a/lib/bing-ads-reporting/version.rb
+++ b/lib/bing-ads-reporting/version.rb
@@ -1,3 +1,3 @@
 module BingAdsReporting
-  VERSION = '6.0.4'.freeze
+  VERSION = '6.0.5'.freeze
 end


### PR DESCRIPTION
## Description

Fix httparty dependency issue.

Previous strict link to `httparty` version was producing dependency conflicts when trying to bundle f3d-job v4.1.9 in bing provider